### PR TITLE
Use cached 100ms room

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # Firely.co
+
+This project provides a simple backend for managing 100ms rooms. The
+`/api/get-token` endpoint will reuse an existing room if available and only
+create a new room when needed. You can force a new room by adding the query
+parameter `?new=true`.


### PR DESCRIPTION
## Summary
- keep the last created room and only create a new one when needed
- allow forcing a new room via `?new=true`
- document the endpoint behaviour in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684197f17da8832da4314aeed17e588b