### PR TITLE
Switch to 100ms prebuilt UI

### DIFF
--- a/Debate_RoomV2/Frontend/.env
+++ b/Debate_RoomV2/Frontend/.env
@@ -1,0 +1,1 @@
+REACT_APP_HMS_SUBDOMAIN=your-subdomain

--- a/Debate_RoomV2/Frontend/src/App.js
+++ b/Debate_RoomV2/Frontend/src/App.js
@@ -1,14 +1,10 @@
 // frontend_join_with_room_id.js
 import React, { useEffect, useState } from 'react';
-import { useHMSActions } from '@100mslive/react-sdk';
-import RoomPage from './RoomPage';
 
 function JoinButton() {
-  const hmsActions = useHMSActions();
   const [token, setToken] = useState(null);
   const [roomId, setRoomId] = useState(null);
   const [status, setStatus] = useState("Fetching token...");
-  const [joined, setJoined] = useState(false);
   const [role, setRole] = useState('audience');
   useEffect(() => {
     async function fetchToken() {
@@ -36,27 +32,17 @@ function JoinButton() {
 
     fetchToken();
   }, [role]);
-const joinRoom = async () => {
-  if (!token) return;
-  try {
-    setStatus("Joining room...");
-    await hmsActions.join({ userName: role, authToken: token });
-    setStatus("Successfully joined the room!");
-    console.log('🚪 Joined room:', roomId);
-    setJoined(true);
-  } catch (error) {
-    console.error('❌ Join room failed:', error.message, error);
-    if (error && error.description) {
-      console.error('🔍 Description:', error.description);
+
+  const joinRoom = () => {
+    if (!token || !roomId) return;
+    const subdomain = process.env.REACT_APP_HMS_SUBDOMAIN;
+    if (!subdomain) {
+      setStatus('HMS subdomain not set');
+      return;
     }
-    setStatus(`Join room failed: ${error.message}`);
-  }
-};
-
-
-  if (joined) {
-    return <RoomPage role={role} token={token} />;
-  }
+    const url = `https://${subdomain}.app.100ms.live/meeting/${roomId}?token=${token}`;
+    window.location.href = url;
+  };
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- open 100ms prebuilt meeting after joining
- add `.env` for HMS subdomain

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_b_6842b330db74832db7e33ee1d413e5a0