### PR TITLE
Add troubleshooting guidance and dependency override

### DIFF
--- a/Debate_RoomV2/Frontend/package.json
+++ b/Debate_RoomV2/Frontend/package.json
@@ -13,6 +13,9 @@
     "react-scripts": "^5.0.1",
     "web-vitals": "^2.1.4"
   },
+  "overrides": {
+    "@tldraw/state": "1.0.0"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/README.md
+++ b/README.md
@@ -12,3 +12,28 @@ or **audience**. Pass `?role=` in the `/api/get-token` request to specify the
 role. Internally these are mapped to the default 100ms roles `host` and `guest`
 so tokens remain valid. The original role is stored as `app_role` inside the
 token. Judges can submit scores for speakers using the `/api/score` endpoint.
+
+## Troubleshooting
+
+### Duplicate `@tldraw/state` warning
+
+If the frontend shows a warning about multiple versions of `@tldraw/state`,
+ensure a single version is installed by adding an **overrides** section to
+`Debate_RoomV2/Frontend/package.json`:
+
+```json
+  "overrides": {
+    "@tldraw/state": "1.0.0"
+  }
+```
+
+Remove the `node_modules` directory and reinstall packages after editing the
+file.
+
+### 400 errors when fetching tokens
+
+The console may display `POST https://prod-in2.100ms.live/.../api/token 400` if
+the backend credentials or frontend subdomain are incorrect. Verify the
+backend `.env` file contains valid `MANAGEMENT_TOKEN`, `APP_ACCESS_KEY`,
+`APP_SECRET` and `TEMPLATE_ID` values. The frontend `.env` should set
+`REACT_APP_HMS_SUBDOMAIN` to your 100ms subdomain.


### PR DESCRIPTION
## Summary
- add an `overrides` section in the frontend `package.json` to enforce a single version of `@tldraw/state`
- document solutions for the duplicate `@tldraw/state` warning
- document how to resolve HTTP 400 errors when fetching tokens

## Testing
- `CI=true npm test --silent -- --passWithNoTests` in `Debate_RoomV2/Frontend`
- `npm test --silent` in `Debate_RoomV2/Backend`

------
https://chatgpt.com/codex/tasks/task_b_6842bba3d330832dab276dc8abe36b72