### PR TITLE
Switch to custom room interface

### DIFF
--- a/Debate_RoomV2/Frontend/src/App.js
+++ b/Debate_RoomV2/Frontend/src/App.js
@@ -1,6 +1,6 @@
 // frontend_join_with_room_id.js
 import React, { useEffect, useState } from 'react';
-import PrebuiltRoom from './PrebuiltRoom';
+import CustomRoom from './CustomRoom';
 
 function JoinButton() {
   const [token, setToken] = useState(null);
@@ -42,7 +42,7 @@ const joinRoom = () => {
 
 
   if (joined) {
-    return <PrebuiltRoom roomId={roomId} token={token} />;
+    return <CustomRoom token={token} />;
   }
 
   return (

--- a/Debate_RoomV2/Frontend/src/CustomRoom.js
+++ b/Debate_RoomV2/Frontend/src/CustomRoom.js
@@ -1,0 +1,52 @@
+import React, { useEffect } from 'react';
+import {
+  HMSRoomProvider,
+  useHMSStore,
+  useHMSActions,
+  selectPeers,
+  selectIsConnectedToRoom,
+  useVideo
+} from '@100mslive/react-sdk';
+
+const PeerTile = ({ peer }) => {
+  const { videoRef } = useVideo({ trackId: peer.videoTrack });
+  return (
+    <div style={{ display: 'inline-block', margin: '10px', textAlign: 'center' }}>
+      <video ref={videoRef} autoPlay playsInline muted={peer.isLocal} style={{ width: '200px' }} />
+      <div>{peer.name}</div>
+    </div>
+  );
+};
+
+const RoomInner = ({ token }) => {
+  const hmsActions = useHMSActions();
+  const isConnected = useHMSStore(selectIsConnectedToRoom);
+  const peers = useHMSStore(selectPeers);
+
+  useEffect(() => {
+    if (token && !isConnected) {
+      hmsActions.join({ authToken: token, userName: 'Guest' });
+    }
+  }, [token, isConnected, hmsActions]);
+
+  if (!isConnected) {
+    return <div>Joining room...</div>;
+  }
+
+  return (
+    <div>
+      {peers.map(peer => (
+        <PeerTile key={peer.id} peer={peer} />
+      ))}
+    </div>
+  );
+};
+
+export default function CustomRoom({ token }) {
+  if (!token) return null;
+  return (
+    <HMSRoomProvider>
+      <RoomInner token={token} />
+    </HMSRoomProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple custom room component using the 100ms React SDK
- load the new component after joining instead of the prebuilt iframe

## Testing
- `npm test --prefix Debate_RoomV2/Backend` *(fails: no test specified)*
- `npm test --prefix Debate_RoomV2/Frontend --silent`

------
https://chatgpt.com/codex/tasks/task_b_6843f72d1360832db85b385a54a41f1d