### PR TITLE
Add speaker timer

### DIFF
--- a/Debate_RoomV2/Frontend/src/App.jsx
+++ b/Debate_RoomV2/Frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { HMSPrebuilt } from '@100mslive/roomkit-react';
+import SpeakerTimer from './SpeakerTimer';
 
 function App() {
   const [role, setRole] = useState('audience');
@@ -25,9 +26,12 @@ function App() {
   };
 
   if (token) {
-       return ( <div style={{ height: '100vh' }}>
+    return (
+      <div style={{ position: 'relative', height: '100vh' }}>
         <HMSPrebuilt authToken={token} />
-      </div> );
+        <SpeakerTimer />
+      </div>
+    );
   }
 
   return (

--- a/Debate_RoomV2/Frontend/src/SpeakerTimer.jsx
+++ b/Debate_RoomV2/Frontend/src/SpeakerTimer.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import { useHMSActions, useParticipants } from '@100mslive/react-sdk';
+
+const DURATION = 120; // seconds per speaker
+
+export default function SpeakerTimer() {
+  const { participants: speakers } = useParticipants({ role: 'speaker' });
+  const actions = useHMSActions();
+  const [index, setIndex] = useState(0);
+  const activeSpeaker = speakers[index];
+  const [timeLeft, setTimeLeft] = useState(DURATION);
+
+  useEffect(() => {
+    setTimeLeft(DURATION);
+  }, [activeSpeaker]);
+
+  useEffect(() => {
+    if (!activeSpeaker) return;
+    const id = setInterval(() => setTimeLeft(t => t - 1), 1000);
+    return () => clearInterval(id);
+  }, [activeSpeaker]);
+
+  useEffect(() => {
+    if (timeLeft <= 0 && activeSpeaker) {
+      if (activeSpeaker.isLocal) {
+        actions.setLocalAudioEnabled(false);
+      } else if (activeSpeaker.audioTrack) {
+        actions.setRemoteTrackEnabled(activeSpeaker.audioTrack, false);
+      }
+      nextSpeaker();
+    }
+  }, [timeLeft, activeSpeaker, actions]);
+
+  const nextSpeaker = () => {
+    if (speakers.length === 0) return;
+    setIndex((prev) => (prev + 1) % speakers.length);
+  };
+
+  const resetTimer = () => setTimeLeft(DURATION);
+
+  if (!activeSpeaker) return null;
+
+  return (
+    <div style={{ position: 'absolute', top: 10, right: 10, background: '#0008', color: '#fff', padding: '10px', borderRadius: '4px' }}>
+      <p>Speaker: {activeSpeaker.name}</p>
+      <p>Time left: {timeLeft}s</p>
+      <button onClick={resetTimer}>Reset</button>
+      <button onClick={nextSpeaker} style={{ marginLeft: '4px' }}>Next</button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add speaker timer overlay
- embed timer when connected to a room

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_b_684430103304832dabbbad17565f2479