### PR TITLE
Remove score endpoint and document custom UI

### DIFF
--- a/Debate_RoomV2/Backend/server.js
+++ b/Debate_RoomV2/Backend/server.js
@@ -16,8 +16,6 @@ const APP_SECRET = process.env.APP_SECRET;
 // Cache the last created room so we don't create a new one for every request
 let currentRoom = null;
 let roomPromise = null; // ensure only one room is created at a time
-// In-memory storage for speaker scores
-const scores = {};
 // Mapping from app roles to 100ms roles
 const ROLE_MAP = {
   judge: 'judge',
@@ -111,31 +109,6 @@ app.get('/api/get-token', async (req, res) => {
   }
 });
 
-// Endpoint for judges to submit scores for speakers
-app.post('/api/score', (req, res) => {
-  try {
-    const authHeader = req.headers.authorization || '';
-    const token = authHeader.replace('Bearer ', '');
-    const decoded = jwt.verify(token, process.env.APP_SECRET);
-    if (decoded.app_role !== 'judge') {
-      return res.status(403).json({ error: 'Only judges can score' });
-    }
-
-    const { speakerId, score } = req.body;
-    if (!speakerId || typeof score !== 'number') {
-      return res.status(400).json({ error: 'Invalid payload' });
-    }
-
-    if (!scores[speakerId]) {
-      scores[speakerId] = [];
-    }
-    scores[speakerId].push(score);
-    res.json({ success: true });
-  } catch (err) {
-    console.error('Score submission failed:', err.message);
-    res.status(400).json({ error: 'Score submission failed' });
-  }
-});
 
 app.listen(PORT, () => {
   console.log(`🚀 Server running on http://localhost:${PORT}`);

--- a/README.md
+++ b/README.md
@@ -11,4 +11,11 @@ Users join a room with one of four roles: **judge**, **speaker**, **moderator**
 or **audience**. Pass `?role=` in the `/api/get-token` request to specify the
 role. Internally these are mapped to the default 100ms roles `host` and `guest`
 so tokens remain valid. The original role is stored as `app_role` inside the
-token. Judges can submit scores for speakers using the `/api/score` endpoint.
+token.
+
+## Frontend
+
+The UI is built using the `@100mslive/react-sdk` to provide a custom
+experience similar to 100ms' own SDK examples. It does **not** use the
+prebuilt component. Run `npm start` inside `Debate_RoomV2/Frontend` to launch
+the development server.


### PR DESCRIPTION
## Summary
- remove judge scoring feature from server
- clarify in README that the frontend uses a custom UI built with the 100ms React SDK

## Testing
- `npm test` in `Debate_RoomV2/Backend` *(fails: Error: no test specified)*
- `npm test` in `Debate_RoomV2/Frontend` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_684bc83c6124832db7e0511bf3629e3f