### PR TITLE
Improve speaker auto mute logic

### DIFF
--- a/Debate_RoomV2/Frontend/src/components/CustomRoom.jsx
+++ b/Debate_RoomV2/Frontend/src/components/CustomRoom.jsx
@@ -86,6 +86,7 @@ function RoomInner({ token, role, userName }) {
 
   const handleAudioStateChange = useCallback(() => {
     if (!activeSpeaker || !localPeer) return;
+    if (localPeer.roleName !== 'speaker') return;
     if (activeSpeaker === localPeer.id && !isLocalAudioEnabled) {
       setTimers(prev => {
         const newTimers = { ...prev };
@@ -155,6 +156,7 @@ function RoomInner({ token, role, userName }) {
 
   useEffect(() => {
     if (!isConnected || activeSpeaker || !localPeer) return;
+    if (localPeer.roleName !== 'speaker') return;
 
     const speakerPeers = peers
       .filter(p => p.roleName === 'speaker')
@@ -167,6 +169,7 @@ function RoomInner({ token, role, userName }) {
 
   const updateAudioState = useCallback(async () => {
     if (!isConnected || !localPeer) return;
+    if (localPeer.roleName !== 'speaker') return;
     
     const shouldBeEnabled = activeSpeaker === localPeer.id;
     if (shouldBeEnabled !== isLocalAudioEnabled) {
@@ -184,6 +187,7 @@ function RoomInner({ token, role, userName }) {
 
   useEffect(() => {
     if (!isConnected || !activeSpeaker || !localPeer) return;
+    if (localPeer.roleName !== 'speaker') return;
     
     const start = timers[activeSpeaker];
     if (!start || activeSpeaker !== localPeer.id) return;


### PR DESCRIPTION
## Summary
- limit automatic audio muting/unmuting to the `speaker` role so that judges and other roles are unaffected

## Testing
- `npm test --silent` in `Backend` *(fails: `Error: no test specified`)*
- `npm test --silent -- -u` in `Frontend` *(failed: react-scripts not found due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_b_685256c531c4832d9d8d76a0f355c0a5