### PR TITLE
Add moderator speaking order controls

### DIFF
--- a/Debate_RoomV2/Frontend/src/components/CustomRoom.css
+++ b/Debate_RoomV2/Frontend/src/components/CustomRoom.css
@@ -207,4 +207,26 @@ video {
   -moz-context-menu: none;
   -ms-context-menu: none;
   context-menu: none;
-} 
+}
+
+.speaking-order {
+  margin-top: 20px;
+  background: white;
+  padding: 10px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.speaking-order ol {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.speaking-order li {
+  margin-bottom: 4px;
+}
+
+.speaking-order button {
+  margin-left: 4px;
+  padding: 2px 6px;
+}


### PR DESCRIPTION
## Summary
- add a `SpeakingOrder` panel for moderators
- broadcast speaking order updates
- allow moderators to pick the next speaker
- style speaking order list

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in Backend *(prints "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_b_68528677e93c832dba6e063da98e7732