### PR TITLE
Add moderator speaker queue controls

### DIFF
--- a/Debate_RoomV2/Frontend/src/components/CustomRoom.css
+++ b/Debate_RoomV2/Frontend/src/components/CustomRoom.css
@@ -209,24 +209,30 @@ video {
   context-menu: none;
 }
 
-.speaking-order {
+.speaker-queue {
   margin-top: 20px;
   background: white;
   padding: 10px;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
+.speaker-queue ol {
+  margin: 0;
+  padding-left: 20px;
+}
+.speaker-queue li {
+  margin-bottom: 4px;
+}
+.speaker-queue button {
+  margin-left: 4px;
+  padding: 2px 6px;
+}
 
-.speaking-order ol {
+.speaker-queue ul {
   margin: 0;
   padding-left: 20px;
 }
 
-.speaking-order li {
+.speaker-queue ul li {
   margin-bottom: 4px;
-}
-
-.speaking-order button {
-  margin-left: 4px;
-  padding: 2px 6px;
 }


### PR DESCRIPTION
## Summary
- implement `SpeakerQueue` component with add/remove/move controls
- allow moderator to broadcast queue updates via custom event
- automatically start the next queued speaker when timer ends

## Testing
- `npm test --prefix Debate_RoomV2/Frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852d50cfbac832da9ac4e0511f04ec9