### PR TITLE
Fix reference error in CustomRoom

### DIFF
--- a/Debate_RoomV2/Frontend/src/components/CustomRoom.jsx
+++ b/Debate_RoomV2/Frontend/src/components/CustomRoom.jsx
@@ -340,6 +340,23 @@ function RoomInner({ token, role, userName }) {
     [role, sendQueueEvent]
   );
 
+  const startSpeaker = useCallback(
+    peerId => {
+      if (!isConnected) return;
+      // Prevent starting the same speaker again
+      if (activeSpeaker === peerId) return;
+
+      const start = Date.now();
+      sendEvent({ peerId, start });
+      setActiveSpeaker(peerId);
+      setTimers({ [peerId]: start });
+      // Reset pause state for new speaker
+      setPauseTimes({});
+      setIsPaused(false);
+    },
+    [sendEvent, isConnected, activeSpeaker]
+  );
+
   const startFromModerator = useCallback(
     peerId => {
       startSpeaker(peerId);
@@ -378,23 +395,6 @@ function RoomInner({ token, role, userName }) {
       setChatInput('');
     },
     [chatInput, hmsActions, isConnected],
-  );
-
-  const startSpeaker = useCallback(
-    peerId => {
-      if (!isConnected) return;
-      // Prevent starting the same speaker again
-      if (activeSpeaker === peerId) return;
-      
-      const start = Date.now();
-      sendEvent({ peerId, start });
-      setActiveSpeaker(peerId);
-      setTimers({ [peerId]: start });
-      // Reset pause state for new speaker
-      setPauseTimes({});
-      setIsPaused(false);
-    },
-    [sendEvent, isConnected, activeSpeaker],
   );
 
   const startNextSpeaker = useCallback(() => {


### PR DESCRIPTION
## Summary
- define `startSpeaker` before it is referenced in `startFromModerator`

## Testing
- `npm test --silent -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852d820a658832db35fd9dedb59bb91