### PR TITLE
Add shareable join links

### DIFF
--- a/Debate_RoomV2/Backend/server.js
+++ b/Debate_RoomV2/Backend/server.js
@@ -95,12 +95,18 @@ app.get('/api/get-token', async (req, res) => {
   try {
     const forceNew = req.query.new === 'true';
     const appRole = req.query.role || 'audience';
-    
+    const roomIdParam = req.query.roomId;
+
     if (!ROLE_MAP[appRole]) {
       return res.status(400).json({ error: 'invalid role' });
     }
-    // Reuse the existing room if available unless a new one is requested
-    const room = await getCurrentRoom(forceNew);
+    let room;
+    if (roomIdParam) {
+      room = { id: roomIdParam };
+    } else {
+      // Reuse the existing room if available unless a new one is requested
+      room = await getCurrentRoom(forceNew);
+    }
     console.log(`[ROOM] Using room ${room.id}`);
     const userId = 'user-' + Date.now();
     const token = generateToken(userId, room.id, appRole);

--- a/Debate_RoomV2/Frontend/src/App.css
+++ b/Debate_RoomV2/Frontend/src/App.css
@@ -167,3 +167,28 @@
     margin: 1rem;
   }
 } 
+.invite-link {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
+.invite-link input {
+  flex: 1;
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background-color: #fff;
+  color: #000;
+}
+
+.invite-link button {
+  padding: 0.5rem 1rem;
+  background-color: #4CAF50;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/Debate_RoomV2/Frontend/src/App.jsx
+++ b/Debate_RoomV2/Frontend/src/App.jsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { HMSRoomProvider } from '@100mslive/react-sdk';
 import CustomRoom from './components/CustomRoom';
+import InviteLink from './components/InviteLink';
 
 
 function App() {
@@ -12,6 +13,14 @@ function App() {
   const [isLoading, setIsLoading] = useState(false);
   const [userName, setUserName] = useState('');
 
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const rid = params.get('roomId');
+    const r = params.get('role');
+    if (rid) setRoomId(rid);
+    if (r) setRole(r);
+  }, []);
+
   const joinRoom = async () => {
     if (!userName.trim()) {
       setStatus('Please enter your name');
@@ -20,7 +29,10 @@ function App() {
     setIsLoading(true);
     setStatus('Fetching token...');
     try {
-      const resp = await fetch(`http://localhost:3001/api/get-token?role=${role}&name=${encodeURIComponent(userName.trim())}`);
+      const roomParam = roomId ? `&roomId=${roomId}` : '';
+      const resp = await fetch(
+        `http://localhost:3001/api/get-token?role=${role}${roomParam}&name=${encodeURIComponent(userName.trim())}`
+      );
       const data = await resp.json();
       if (!resp.ok) {
         throw new Error(data.error || 'Failed to fetch token');
@@ -41,6 +53,7 @@ function App() {
     <HMSRoomProvider>
       {token ? (
         <div style={{ height: '100vh' }}>
+          <InviteLink roomId={roomId} />
           <CustomRoom token={token} role={role} userName={userName} />
         </div>
       ) : (

--- a/Debate_RoomV2/Frontend/src/components/InviteLink.jsx
+++ b/Debate_RoomV2/Frontend/src/components/InviteLink.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function InviteLink({ roomId }) {
+  if (!roomId) return null;
+  const inviteURL = `${window.location.origin}?roomId=${roomId}`;
+
+  const copyLink = () => {
+    navigator.clipboard.writeText(inviteURL).catch(err => console.error('Copy failed', err));
+  };
+
+  return (
+    <div className="invite-link">
+      <input type="text" readOnly value={inviteURL} onFocus={e => e.target.select()} />
+      <button onClick={copyLink}>Copy Link</button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add roomId support in backend to generate tokens for existing rooms
- expose invite link UI in frontend and parse URL params

## Testing
- `npm test` (backend) *(fails: no test specified)*
- `npm test --silent` (frontend) *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_685398c679f4832d99d97de0890a2cb3